### PR TITLE
fix: package.json dist path

### DIFF
--- a/packages/electron-tools/src/build/create-pkg.ts
+++ b/packages/electron-tools/src/build/create-pkg.ts
@@ -91,12 +91,12 @@ export const createNodeModulesPkg = (options: {
   });
 
   // create package.json for main process.
-  const pkgFolder = dirname(APP_PACKAGE_JSON_FILE_PATH);
+  const distPackagejson = getDistPackageJsonPath(userProjectPath);
+  const pkgFolder = dirname(distPackagejson);
   if (!existsSync(pkgFolder)) {
     mkdirpSync(pkgFolder);
   }
 
-  const distPackagejson = getDistPackageJsonPath(userProjectPath);
   cliLog.info('distPackagejson:', distPackagejson);
   writeJsonSync(
     distPackagejson,


### PR DESCRIPTION
- Fix package.json of dist path when change app builder config.
- Compatible with electron-builder 22.10.x.
- Fix the parameter passing problem during building main process.