### PR TITLE
Fix build main cmd v2

### DIFF
--- a/packages/electron-runtime/src/core/base/parts/ipc/node/ipc.ts
+++ b/packages/electron-runtime/src/core/base/parts/ipc/node/ipc.ts
@@ -113,9 +113,10 @@ export function createChannelSender<T>(
       get(_target: T, propKey: PropertyKey) {
         if (typeof propKey === 'string') {
           // Event
-          if (propertyIsEvent(propKey)) {
-            return channel.listen(propKey);
-          }
+          // this will effect services which can't use name startWithOn
+          // if (propertyIsEvent(propKey)) {
+          //   return channel.listen(propKey);
+          // }
 
           // Function
           return async function (...args: any[]) {

--- a/packages/electron-tools/cli.js
+++ b/packages/electron-tools/cli.js
@@ -63,6 +63,8 @@ program
       env: processEnv,
       compileOptions,
       mainProcessFolder: options.main,
+      extra: options.extra,
+      ignore: options.ignore,
     });
   });
 

--- a/packages/electron-tools/src/build/create-pkg.ts
+++ b/packages/electron-tools/src/build/create-pkg.ts
@@ -91,12 +91,12 @@ export const createNodeModulesPkg = (options: {
   });
 
   // create package.json for main process.
-  const pkgFolder = dirname(APP_PACKAGE_JSON_FILE_PATH);
+  const distPackagejson = getDistPackageJsonPath(userProjectPath);
+  const pkgFolder = dirname(distPackagejson);
   if (!existsSync(pkgFolder)) {
     mkdirpSync(pkgFolder);
   }
 
-  const distPackagejson = getDistPackageJsonPath(userProjectPath);
   cliLog.info('distPackagejson:', distPackagejson);
   writeJsonSync(
     distPackagejson,

--- a/packages/electron-tools/src/deps/index.ts
+++ b/packages/electron-tools/src/deps/index.ts
@@ -5,7 +5,7 @@ import { join, dirname } from 'path';
 import { existsSync } from 'fs-extra';
 import { getArchAndPlatform } from '../utils/platform';
 import { spawnPromise } from '../utils/spawn';
-import { YARN_BIN } from '../utils/bins';
+import { getElectronBuilderBin, YARN_BIN } from '../utils/bins';
 import { ENV_NAME } from '@/utils';
 
 export const installDep = (compileFolder: string, installCmd?: string) => {
@@ -28,7 +28,7 @@ export const installDep = (compileFolder: string, installCmd?: string) => {
 };
 
 export const compileDep = (compileFolder: string) => {
-  const electronBuilderBin = require.resolve('electron-builder/cli.js');
+  const electronBuilderBin = getElectronBuilderBin();
   const pcInfo = getArchAndPlatform();
   return spawnPromise({
     cmd: electronBuilderBin,

--- a/packages/electron-tools/src/pack/pack.ts
+++ b/packages/electron-tools/src/pack/pack.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import spawn from 'cross-spawn';
+import { getElectronBuilderBin } from '@/utils';
 
 export type PLATFORM = 'mac' | 'win32' | 'win64' | 'linux' | 'linuxArm64';
 
@@ -34,7 +35,7 @@ const doPack = (options: {
   version: string;
 }) => {
   const { userProjectPath, env, version, platform } = options;
-  const electronBuilderBin = require.resolve('electron-builder/cli.js');
+  const electronBuilderBin = getElectronBuilderBin();
   const exec = spawn(electronBuilderBin, getPackParams({ version, platform }), {
     cwd: userProjectPath,
     env: {

--- a/packages/electron-tools/src/utils/bins.ts
+++ b/packages/electron-tools/src/utils/bins.ts
@@ -1,3 +1,17 @@
 import os from 'os';
 
 export const YARN_BIN = os.platform() === 'darwin' ? 'yarn' : 'yarn.cmd';
+
+export const getElectronBuilderBin = () => {
+  try {
+    // electron-builder >= 22.13
+    return require.resolve('electron-builder/cli.js');
+  } catch (error) {
+    // electron-builder >= 22.10
+    try {
+      return require.resolve('electron-builder/out/cli/cli.js');
+    } catch (_err) {
+      throw Error('electron-builder version should >=22.10.0');
+    }
+  }
+};


### PR DESCRIPTION
- Fix package.json of dist path when change app builder config.
- Compatible with electron-builder 22.10.x.
- Fix the parameter passing problem during building main process.