### PR TITLE
fix: babel compile sourcemap option

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,10 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "node --max_old_space_size=8192 ./node_modules/.bin/eslint --fix --color --cache --quiet",
-      "git add"
+      "pnpm eslint --fix --color --cache --quiet"
     ],
     "*.{js,jsx,mjs,mjsx,cjs,cjsx}": [
-      "node --max_old_space_size=8192 ./node_modules/.bin/eslint --fix --color --cache --quiet",
-      "git add"
+      "pnpm eslint --fix --color --cache --quiet"
     ]
   },
   "eslintConfig": {

--- a/packages/electron-runtime/modern.config.js
+++ b/packages/electron-runtime/modern.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 /** @type {import('@modern-js/module-tools').UserConfig} */
 module.exports = {
   output: {
@@ -11,7 +13,7 @@ module.exports = {
       opts.plugins = opts.plugins.slice(1, opts.plugins.length);
       opts.plugins.push(['@vjpr/babel-plugin-parameter-decorator', {}]);
       const preset = opts.presets.filter(p =>
-        p[0].includes('@babel/preset-typescript'),
+        p[0].includes(path.normalize('@babel/preset-typescript')),
       )[0];
       preset[1].onlyRemoveTypeImports = true;
       preset[1].isTSX = false;

--- a/packages/electron-tools/src/build/compile.ts
+++ b/packages/electron-tools/src/build/compile.ts
@@ -80,11 +80,7 @@ const doCompile = (options: {
 
   compileOptions.ignore = compileOptions.ignore || [];
   compileOptions.ignore = compileOptions.ignore.concat(DEFAULT_IGNORE);
-
-  console.log('compile options:', compileOptions, {
-    ...babelConfig,
-    minified: getMinified(),
-  });
+  babelConfig.sourceMaps = compileOptions.sourceMaps;
   return compiler(
     { ...defaultCompileOptions, ...compileOptions },
     {


### PR DESCRIPTION
1. pass through sourceMaps options to modern-js/babel-compiler，fix sourceMaps is not generated while sourceMaps options set to true。
2. by the way, fix some windows platform development problem.
2.1 use pnpm to find the correct scripts to exec.
2.2 use path.normalize to process path in any platform.