### PR TITLE
fix: allow to change main process runtime and plugin package name

### DIFF
--- a/.changeset/lemon-snakes-heal.md
+++ b/.changeset/lemon-snakes-heal.md
@@ -1,0 +1,7 @@
+---
+"@modern-js/electron-tools": patch
+---
+
+fix: allow to change main process runtime and plugin package name
+
+fix: 允许修改主进程 runtime 和 plugin 包名

--- a/packages/electron-tools/src/babel-plugin/replace-pkg-name.ts
+++ b/packages/electron-tools/src/babel-plugin/replace-pkg-name.ts
@@ -5,6 +5,7 @@
  */
 
 import { types, NodePath } from '@babel/core';
+import { ENVS } from '../utils/constant';
 
 export type ImportStyleType = 'source-code' | 'compiled-code';
 export interface IImportPathOpts {
@@ -12,8 +13,14 @@ export interface IImportPathOpts {
   importStyle?: ImportStyleType;
 }
 
-const MODERN_JS_NAME = '@modern-js/runtime';
-const ELECTRON_PLUGIN_NAME = '@modern-js/plugin-electron';
+// Allow to modify package names via env variables
+const MODERN_JS_NAME =
+  process.env[ENVS.ELECTRON_RUNTIME_PKG_NAME] || '@modern-js/runtime';
+const ELECTRON_PLUGIN_NAME =
+  process.env[ENVS.ELECTRON_PLUGIN_PKG_NAME] || '@modern-js/plugin-electron';
+
+console.log('MODERN_JS_NAME', MODERN_JS_NAME);
+console.log('ELECTRON_PLUGIN_NAME', ELECTRON_PLUGIN_NAME);
 
 // preload may have bridge or webview or render
 const INNER_PKGS_MAP = {

--- a/packages/electron-tools/src/utils/constant.ts
+++ b/packages/electron-tools/src/utils/constant.ts
@@ -5,4 +5,6 @@ export const ENV_NAME = {
 
 export const ENVS = {
   ELECTRON_BUILD_ENV: 'ELECTRON_BUILD_ENV', // build with env: [development、production]，it's not same as NODE_ENV. it means -d option
+  ELECTRON_RUNTIME_PKG_NAME: 'ELECTRON_RUNTIME_PKG_NAME',
+  ELECTRON_PLUGIN_PKG_NAME: 'ELECTRON_PLUGIN_PKG_NAME',
 };


### PR DESCRIPTION
The package imported in main process entry may not always be `@modern-js/runtime` and `@modern-js/plugin-electron`.

```ts
import { app } from 'electron';
import Runtime, { winService } from '@modern-js/runtime/electron-main';
//                                   ^^^^^^^^^^^^^^^^^^
//                                   could be other ones, eg. @jupiter/plugin-runtime
```

This PR allows to change the package names outside electron-tools via environments.